### PR TITLE
records retry

### DIFF
--- a/lib/sidekiq/metrics/middleware.rb
+++ b/lib/sidekiq/metrics/middleware.rb
@@ -24,6 +24,7 @@ module Sidekiq
         raise e
       ensure
         finish = Time.now
+        worker_status[:retry] = !!msg['retry']
         worker_status[:queue]= msg['queue'] || queue
         worker_status[:class] = worker.class.to_s
         worker_status[:jid] = msg['jid']

--- a/spec/sidekiq/metrics/middleware_spec.rb
+++ b/spec/sidekiq/metrics/middleware_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe Sidekiq::Metrics::Middleware do
       expect(parsed_logs.count).to eq 500
     end
 
+    it 'records retry' do
+      middlewared(TestWorker, { 'retry' => true }) {}
+      middlewared(TestWorker, { 'retry' => false }) {}
+      middlewared(TestWorker) {}
+
+      expect(parsed_logs[0]['retry']).to eq true
+      expect(parsed_logs[1]['retry']).to eq false
+      expect(parsed_logs[2]['retry']).to eq false
+    end
+
     it 'records class' do
       middlewared(TestWorker) {}
       middlewared(TestWithQueueWorker) {}


### PR DESCRIPTION
add retried information to metric log

```
2019-11-28T08:18:53.736Z pid=75363 tid=ov3jcvmeb class=TestWorker jid=c84c1e92b3ad5e4097852968 INFO: {"status":"passed","retry":true,"queue":"default","class":"TestWorker","jid":"c84c1e92b3ad5e4097852968","enqueued_at":1574929133.733407,"started_at":1574929133.736893,"finished_at":1574929133.736906}
```